### PR TITLE
Cleanup date filter

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,18 +20,7 @@ class ReportsController < ApplicationController
   end
 
   def history
-    @reports = Report.where(status: 'completed').page(params[:page])
-  end
-
-  def filter
-    @reports  = ReportFilter.new(params['filter']).query if params['filter'].present?
-
-    report_id = params[:report][:id] if params[:report]
-    @report   = Report.find(report_id) if report_id.present?
-
-    respond_to do |format|
-      format.js
-    end
+    @reports = ReportFilter.new(params).query.page(params[:page])
   end
 
   def deleted

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -1,31 +1,26 @@
 class ReportFilter
-  WHITELIST_ATTRIBUTES = %w(name phone start_date end_date responder)
 
   def initialize(params)
-    @params     = params.keep_if {|key,val| WHITELIST_ATTRIBUTES.include?(key)}
     start_date  = params[:start_date]
     end_date    = params[:end_date]
-
-    @responder_params = params[:responder]
+    
+    order       = params[:order]
+    order       = order.present? ? order : 'desc' && params[:order] = 'desc'
+    @order      = "created_at #{order}"
 
     @start_date = Date.parse(start_date).end_of_day if start_date.present?
     @end_date   = Date.parse(end_date).end_of_day if end_date.present?
   end
 
-  # NOTE
-  # (in block after) elsif defined?(@responder_params)....
-  # Needed compact once for edge case but cant repeat so feel free to take out
   def query
     if defined?(@start_date) && defined?(@end_date)
-      completed_reports.where('created_at >= ? and created_at <= ?', @start_date, @end_date).order('created_at desc')
+      completed_reports.where('created_at >= ? and created_at <= ?', @start_date, @end_date).order(@order)
     elsif defined?(@start_date)
-      completed_reports.where('created_at >= ?', @start_date).order(:created_at)
+      completed_reports.where('created_at >= ?', @start_date).order(@order)
     elsif defined?(@end_date)
-      completed_reports.where('created_at <= ?', @end_date).order('created_at desc')
-    elsif defined?(@responder_params) && @responder_params.present?
-      Responder.where(@responder_params).map(&:reports).flatten.compact.sort { |a,b| b.created_at <=> a.created_at }
+      completed_reports.where('created_at <= ?', @end_date).order(@order)
     else
-      completed_reports.where(@params).order('created_at desc')
+      completed_reports.where(@params).order(@order)
     end
   end
 

--- a/app/views/dispatches/_dispatch.html.haml
+++ b/app/views/dispatches/_dispatch.html.haml
@@ -2,4 +2,4 @@
   %dt Responder Name
   %dd= link_to dispatch.responder.name, responder_path(dispatch.responder)
   %dt Phone
-  %dd= link_to dispatch.responder.phone, filter_reports_path(report: {id: dispatch.report.id}, filter: {responder: {phone: dispatch.responder.phone}}), remote: true, method: :post
+  %dd= dispatch.responder.phone

--- a/app/views/reports/_report_table.html.haml
+++ b/app/views/reports/_report_table.html.haml
@@ -1,7 +1,12 @@
 %table.table
   %thead
     %tr
-      %th Date
+      %th
+        Date
+        = link_to "<span class='glyphicon glyphicon-chevron-#{params[:order] == 'asc' ? 'down' : 'up'}'></span>".html_safe,
+          history_reports_path(start_date: params[:start_date],
+          end_date: params[:end_date],
+          order: (['desc', 'asc'] - [params[:order]])[0]) if current_page?('/reports/history')
       %th Name
       %th Phone
       %th Patient Description

--- a/app/views/reports/history.html.haml
+++ b/app/views/reports/history.html.haml
@@ -1,12 +1,15 @@
 %h2 History
 = link_to "Deleted Reports", deleted_reports_path
 .row
-  = simple_form_for 'filter', url: filter_reports_path, remote: true do |f|
-    .col-sm-2= f.input :start_date, input_html: {class: 'date col-sm-2'}, label: 'Start'
-    .col-sm-2= f.input :end_date, input_html: {class: 'date col-sm-2'}, label: 'End'
+  = simple_form_for '', url: history_reports_path, method: :get do |f|
+    .col-sm-2= f.input :start_date, label: 'Start',
+      input_html: {class: 'date col-sm-2', value: params[:start_date]}
+    .col-sm-2= f.input :end_date, label: 'End',
+      input_html: {class: 'date col-sm-2', value: params[:end_date]}
     .col-sm-2= f.button :submit, 'Search Dates', style: 'margin-top:25px;'
 %hr
 = render partial: "report_table", locals: { reports: @reports }
+
 = paginate @reports
 
 :javascript

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Streetmom::Application.routes.draw do
       get 'active'
       get 'history'
       get 'deleted'
-      post 'filter'
     end
 
     member do


### PR DESCRIPTION
Removed filter action in report controller since Responder/Respondents have profile pages.  
Now only filtering date in history page.  Also can now reverse date order even when date query is being used. 
