### PR TITLE
Only notify responders once when a report is complete

### DIFF
--- a/app/models/dispatch_messenger.rb
+++ b/app/models/dispatch_messenger.rb
@@ -49,7 +49,6 @@ class DispatchMessenger
   end
 
   def complete
-    @report.complete
     thank_responder
     thank_reporter
   end
@@ -137,9 +136,7 @@ class DispatchMessenger
     message = <<-EOF
       The report is now completed, thanks for your help! You are now available to be dispatched.
     EOF
-    Responder.accepted(@report.id).each do |responder|
-      Telephony.send(message, responder.phone)
-    end
+    Telephony.send(message, @responder.phone)
   end
 
   def thank_reporter

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -25,4 +25,32 @@ describe ReportsController do
   #     end
   #   end
   # end
+
+  context "when completing report" do
+    let(:report) { create(:report, :accepted) }
+    let(:additional_responder) { create(:user, :responder) }
+
+    before do
+      request.env['HTTP_REFERER'] = '/reports'
+    end
+
+    it "notifies dispatchers the report is complete" do
+      report.dispatch(additional_responder.responder)
+
+      report.dispatches.each do |dispatch|
+        dispatch.update_attribute(:status, :accepted)
+      end
+
+      notified = []
+      allow(Telephony).to receive(:send) do |body, to|
+        next unless body =~ /The report is now completed/
+        fail "#{to} has already been notified" if notified.include?(to)
+        notified << to
+      end
+
+      put :update, id: report.id, report: { status: :completed }
+
+      notified.should have(report.responders.count).items
+    end
+  end
 end


### PR DESCRIPTION
We were sending duplicate complete messages because:

* We were marking the report as complete multiple times (which sent
  caused the hook to fire multiple times)
* For each notification, we were notifying every responder

Fixes 116815145

cc/ @channie