### PR TITLE
Only use AWS S3 for paperclip storage in production environments

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,17 +22,5 @@ module Streetmom
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
-
-    config.paperclip_defaults = {
-      :storage => :s3,
-      :s3_credentials => {
-        :bucket => ENV["AWS_BUCKET"],
-        :access_key_id => ENV["AWS_KEY"],
-        :secret_access_key => ENV["AWS_SECRET"]
-      },
-      :s3_host_alias => "concrn.s3.amazonaws.com",
-      :url => ":s3_domain_url",
-      :path => '/:class/:attachment/:id_partition/:style/:filename'
-    }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,4 +15,16 @@ Streetmom::Application.configure do
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
   config.time_zone = "Pacific Time (US & Canada)"
+
+  config.paperclip_defaults = {
+    :storage => :s3,
+    :s3_credentials => {
+      :bucket => ENV["AWS_BUCKET"],
+      :access_key_id => ENV["AWS_KEY"],
+      :secret_access_key => ENV["AWS_SECRET"]
+    },
+    :s3_host_alias => "concrn.s3.amazonaws.com",
+    :url => ":s3_domain_url",
+    :path => '/:class/:attachment/:id_partition/:style/:filename'
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,3 +10,5 @@ Streetmom::Application.configure do
   config.action_mailer.delivery_method = :test
   config.active_support.deprecation = :stderr
 end
+
+Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,8 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
+
+  config.after(:suite) do
+    FileUtils.rm_rf(Dir["#{Rails.root}/spec/test_files/"])
+  end
 end


### PR DESCRIPTION
In development and test, use the local filesystem (the default)