### PR TITLE
Speed up test runs by not calling external services

### DIFF
--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -1,9 +1,13 @@
 class Push
   def self.refresh
+    return Rails.logger.info("skipping pusher refresh") if Rails.env.test?
+
     Pusher.trigger('reports-responders' , "refresh", {})
   end
 
   def self.update_transcript(report_id, log)
+    return Rails.logger.info("skipping pusher update_transcript(#{report_id}, '#{log.inspect}')") if Rails.env.test?
+
     Pusher.trigger("report-#{report_id}", "message", {'inner_html' => LogPresenter.new(log).inner_html, 'id' => log.id})
   end
 end

--- a/app/models/telephony.rb
+++ b/app/models/telephony.rb
@@ -6,7 +6,8 @@ class Telephony
   end
 
   def self.send(body = 'Thanks!', to = nil)
-    return true if Rails.env.test?
+    return Rails.logger.info("skipping SMS send('#{body}', '#{to}')") if Rails.env.test?
+
     client.account.messages.create(from: OUTGOING_PHONE, to: to, body: body)
   rescue => e
     puts "### ERROR: #{e} ###"
@@ -14,6 +15,8 @@ class Telephony
   end
 
   def self.receive(body, opts = {})
+    return Rails.logger.info("skipping SMS receive('#{body}', '#{opts.inspect}')") if Rails.env.test?
+
     responder = Responder.find_by_phone(opts[:from])
     send("#{opts[:from]}: #{opts[:body]}", to: '6507876770') unless responder
     DispatchMessenger.new(responder).respond(body)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,22 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
+Geocoder.configure(:lookup => :test)
+
+Geocoder::Lookup::Test.set_default_stub(
+  [
+    {
+      'latitude'     => 37.7922304,
+      'longitude'    => -122.4061408,
+      'address'      => "717 California St, San Francisco, CA 94108, USA",
+      'state'        => 'San Francisco',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
 RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
Skip calling Twilio or Pusher during tests. Takes runs from 90s to 11s.