### PR TITLE
Change params format to use reporter_params

### DIFF
--- a/app/controllers/reporters_controller.rb
+++ b/app/controllers/reporters_controller.rb
@@ -26,6 +26,6 @@ class ReportersController < DashboardController
   private
 
   def reporter_params
-    params.require(:reporter).permit(:phone, :name, :email, :password, :password_confirmation)
+    params.require(:reporter).permit(:phone, :name, :email, :password, :password_confirmation, :address)
   end
 end

--- a/app/views/reporters/show.html.haml
+++ b/app/views/reporters/show.html.haml
@@ -14,9 +14,9 @@
       - @reports.each do |report|
         = content_tag_for :tr, report, class: row_style(report.current_status) do
           %td= report.created_at.strftime('%-m-%-d-%y')
-          %td= link_to report.address, reporter_path(report, address: report.address)
-          %td= link_to report.name, reporter_path(report, name: report.name)
-          %td= link_to report.phone, reporter_path(report, phone: report.phone)
+          %td= link_to report.address, reporter_path(report, reporter: {address: report.address})
+          %td= link_to report.name, reporter_path(report, reporter: {name: report.name})
+          %td= link_to report.phone, reporter_path(report, reporter: {phone: report.phone})
           %td= report.status
           %td= link_to 'Details', report_path(report)
 - else

--- a/app/views/reports/_report.html.haml
+++ b/app/views/reports/_report.html.haml
@@ -9,9 +9,9 @@
         )
       .show_link= link_to("Show Details", report)
 
-  %td= link_to report.name, reporter_path(report, name: report.name)
+  %td= link_to report.name, reporter_path(report, reporter:{name: report.name})
 
-  %td= link_to report.phone, reporter_path(report, phone: report.phone)
+  %td= link_to report.phone, reporter_path(report, reporter:{phone: report.phone})
 
   %td
     - if report.gender?


### PR DESCRIPTION
App was crashing when clicking on a phone# or name in 'views/reports/index'. The corresponding controller, 'reporters_controller#show,' takes in the private method reporter_params which requires a 'reporter' resource and permits specific values. To fix the bug, it required changing the format of params in 'views/reports/index.'

Also, address was added as a valid input for reporter_params, allowing filtering by address on 'views/reporters/show'